### PR TITLE
TransferManager- Resolves Pause & Resume

### DIFF
--- a/client/internal/connection.go
+++ b/client/internal/connection.go
@@ -60,7 +60,7 @@ func UserInput(attribute string, conn net.Conn) error {
 				input = strings.TrimSpace(input)
 				continue
 			}
-			
+
 			// Check if it's a directory
 			fileInfo, err := os.Stat(input)
 			if err != nil || !fileInfo.IsDir() {
@@ -70,7 +70,7 @@ func UserInput(attribute string, conn net.Conn) error {
 				input = strings.TrimSpace(input)
 				continue
 			}
-			
+
 			break
 		}
 	}
@@ -141,12 +141,12 @@ func ReadLoop(conn net.Conn) {
 			// Improved approach to accumulate the complete user list
 			fmt.Println(utils.HeaderColor("\n👥 Online Users:"))
 			fmt.Println(utils.InfoColor("-------------------"))
-			
+
 			// Read the complete user list with timeout
 			userList := ""
 			tempBuf := make([]byte, 1024)
 			conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-			
+
 			for {
 				m, err := conn.Read(tempBuf)
 				if err != nil {
@@ -157,10 +157,10 @@ func ReadLoop(conn net.Conn) {
 					break // All data received
 				}
 			}
-			
+
 			// Reset the deadline
 			conn.SetReadDeadline(time.Time{})
-			
+
 			// Process users
 			userCount := 0
 			for _, line := range strings.Split(userList, "\n") {
@@ -189,11 +189,11 @@ func ReadLoop(conn net.Conn) {
 					fmt.Println(utils.SuccessColor(" • "), utils.UserColor(line))
 				}
 			}
-			
+
 			if userCount == 0 {
 				fmt.Println(utils.InfoColor(" No users currently online"))
 			}
-			
+
 			fmt.Println(utils.InfoColor("-------------------"))
 			continue
 		case strings.HasPrefix(message, "/LOOK_REQUEST"):
@@ -322,6 +322,27 @@ func WriteLoop(conn net.Conn) {
 			filePath := args[2]
 			fmt.Println(utils.InfoColor("📥 Requesting download from"), utils.UserColor(recipientId))
 			HandleDownloadRequest(conn, recipientId, filePath)
+			continue
+		case strings.HasPrefix(message, "/transfers"):
+			HandleListTransfers()
+			continue
+		case strings.HasPrefix(message, "/pause"):
+			args := strings.SplitN(message, " ", 2)
+			if len(args) != 2 {
+				fmt.Println(utils.ErrorColor("❌ Invalid arguments. Use: /pause <transferId>"))
+				continue
+			}
+			transferID := args[1]
+			HandlePauseTransfer(transferID)
+			continue
+		case strings.HasPrefix(message, "/resume"):
+			args := strings.SplitN(message, " ", 2)
+			if len(args) != 2 {
+				fmt.Println(utils.ErrorColor("❌ Invalid arguments. Use: /resume <transferId>"))
+				continue
+			}
+			transferID := args[1]
+			HandleResumeTransfer(transferID)
 			continue
 		default:
 			if message != "" {

--- a/client/internal/file.go
+++ b/client/internal/file.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
 )
 
 func HandleSendFile(conn net.Conn, recipientId, filePath string) {
@@ -35,56 +37,100 @@ func HandleSendFile(conn net.Conn, recipientId, filePath string) {
 		return
 	}
 
-	fmt.Printf("%s Sending file '%s' to user %s...\n", 
+	transferID := GenerateTransferID()
+	fmt.Printf("%s Sending file '%s' to user %s (Transfer ID: %s)...\n",
 		utils.InfoColor("📤"),
-		utils.InfoColor(fileName), 
-		utils.UserColor(recipientId))
-	
-	// Send file request with file size and checksum
-	_, err = conn.Write([]byte(fmt.Sprintf("/FILE_REQUEST %s %s %d %s\n", 
-		recipientId, fileName, fileSize, checksum)))
+		utils.InfoColor(fileName),
+		utils.UserColor(recipientId),
+		utils.CommandColor(transferID))
+
+	// Send file request with file size, checksum, and transfer ID
+	_, err = conn.Write([]byte(fmt.Sprintf("/FILE_REQUEST %s %s %d %s %s\n",
+		recipientId, fileName, fileSize, checksum, transferID)))
 	if err != nil {
 		fmt.Println(utils.ErrorColor("❌ Error sending file request:"), err)
 		return
 	}
 
-	// Create progress bar
+	// Create progress bar with transfer ID
 	bar := utils.CreateProgressBar(fileSize, "📤 Sending file")
-	
-	// Stream file data using io.TeeReader to update progress bar
-	n, err := io.CopyN(conn, io.TeeReader(file, bar), fileSize)
+	bar.SetTransferId(transferID)
+
+	transfer := &Transfer{
+		ID:            transferID,
+		Type:          FileTransfer,
+		Name:          fileName,
+		Size:          fileSize,
+		BytesComplete: 0,
+		Status:        Active,
+		Direction:     "send",
+		Recipient:     recipientId,
+		Path:          filePath,
+		Checksum:      checksum,
+		StartTime:     time.Now(),
+		File:          file,
+		Connection:    conn,
+		ProgressBar:   bar,
+	}
+
+	RegisterTransfer(transfer)
+
+	reader := NewCheckpointedReader(file, transfer, 32768) // 32KB chunks
+
+	n, err := io.CopyN(conn, io.TeeReader(reader, bar), fileSize)
+
 	if err != nil {
+		UpdateTransferStatus(transferID, Failed)
 		fmt.Println(utils.ErrorColor("\n❌ Error sending file:"), err)
+		RemoveTransfer(transferID)
 		return
 	}
-	
+
 	if n != fileSize {
-		fmt.Println(utils.ErrorColor("\n❌ Error: sent"), utils.ErrorColor(n), 
-		    utils.ErrorColor("bytes, expected"), utils.ErrorColor(fileSize), utils.ErrorColor("bytes"))
+		UpdateTransferStatus(transferID, Failed)
+		fmt.Println(utils.ErrorColor("\n❌ Error: sent"), utils.ErrorColor(n),
+			utils.ErrorColor("bytes, expected"), utils.ErrorColor(fileSize), utils.ErrorColor("bytes"))
+		RemoveTransfer(transferID)
 		return
 	}
-	
-	fmt.Printf("%s File '%s' sent successfully!\n", 
-	    utils.SuccessColor("\n✅"),
-	    utils.SuccessColor(fileName))
+
+	// Mark transfer as completed
+	UpdateTransferStatus(transferID, Completed)
+
+	fmt.Printf("%s File '%s' sent successfully!\n",
+		utils.SuccessColor("\n✅"),
+		utils.SuccessColor(fileName))
 	fmt.Println(utils.InfoColor("  MD5 Checksum:"), utils.InfoColor(checksum))
+
+	// Clean up the transfer
+	RemoveTransfer(transferID)
 }
 
 func HandleFileTransfer(conn net.Conn, recipientId, fileName string, fileSize int64, storeFilePath string) {
-	// Get checksum from the split content
-	parts := strings.SplitN(fileName, "|", 2)
+	// Get checksum and transfer ID from the split content
+	parts := strings.SplitN(fileName, "|", 3)
 	checksum := ""
-	
-	if len(parts) == 2 {
+	transferID := ""
+
+	if len(parts) >= 2 {
 		fileName = parts[0]
 		checksum = parts[1]
 		fmt.Println(utils.InfoColor("📋 Original checksum:"), utils.InfoColor(checksum))
+
+		if len(parts) >= 3 {
+			transferID = parts[2]
+		} else {
+			transferID = GenerateTransferID()
+		}
+	} else {
+		transferID = GenerateTransferID()
 	}
-	
-	fmt.Printf("%s Receiving file: %s (Size: %s)\n", 
+
+	fmt.Printf("%s Receiving file: %s (Size: %s, Transfer ID: %s)\n",
 		utils.InfoColor("📥"),
 		utils.InfoColor(fileName),
-		utils.InfoColor(fmt.Sprintf("%d bytes", fileSize)))
+		utils.InfoColor(fmt.Sprintf("%d bytes", fileSize)),
+		utils.CommandColor(transferID))
 
 	filePath := filepath.Join(storeFilePath, fileName)
 	file, err := os.Create(filePath)
@@ -94,22 +140,49 @@ func HandleFileTransfer(conn net.Conn, recipientId, fileName string, fileSize in
 	}
 	defer file.Close()
 
-	// Create progress bar
+	// Create progress bar with transfer ID
 	bar := utils.CreateProgressBar(fileSize, "📥 Receiving file")
-	
+	bar.SetTransferId(transferID)
+
+	transfer := &Transfer{
+		ID:            transferID,
+		Type:          FileTransfer,
+		Name:          fileName,
+		Size:          fileSize,
+		BytesComplete: 0,
+		Status:        Active,
+		Direction:     "receive",
+		Recipient:     recipientId,
+		Path:          filePath,
+		Checksum:      checksum,
+		StartTime:     time.Now(),
+		File:          file,
+		Connection:    conn,
+		ProgressBar:   bar,
+	}
+
+	RegisterTransfer(transfer)
+
+	writer := NewCheckpointedWriter(file, transfer, 32768) // 32KB chunks
+
 	// Write to file and update progress bar simultaneously
-	n, err := io.CopyN(file, io.TeeReader(conn, bar), fileSize)
+	n, err := io.CopyN(writer, io.TeeReader(conn, bar), fileSize)
+
 	if err != nil {
+		UpdateTransferStatus(transferID, Failed)
 		fmt.Println(utils.ErrorColor("\n❌ Error receiving file:"), err)
+		RemoveTransfer(transferID)
 		return
 	}
-	
+
 	if n != fileSize {
-		fmt.Println(utils.ErrorColor("\n❌ Error: received"), utils.ErrorColor(n), 
-		    utils.ErrorColor("bytes, expected"), utils.ErrorColor(fileSize), utils.ErrorColor("bytes"))
+		UpdateTransferStatus(transferID, Failed)
+		fmt.Println(utils.ErrorColor("\n❌ Error: received"), utils.ErrorColor(n),
+			utils.ErrorColor("bytes, expected"), utils.ErrorColor(fileSize), utils.ErrorColor("bytes"))
+		RemoveTransfer(transferID)
 		return
 	}
-	
+
 	// Verify checksum if provided
 	if checksum != "" {
 		file.Close() // Close file before calculating checksum
@@ -118,7 +191,7 @@ func HandleFileTransfer(conn net.Conn, recipientId, fileName string, fileSize in
 			fmt.Println(utils.ErrorColor("\n❌ Error calculating checksum:"), err)
 		} else {
 			fmt.Println(utils.InfoColor("\n📋 Calculated checksum:"), utils.InfoColor(receivedChecksum))
-			
+
 			if helper.VerifyChecksum(checksum, receivedChecksum) {
 				fmt.Println(utils.SuccessColor("✅ Checksum verification successful! File integrity confirmed."))
 			} else {
@@ -127,10 +200,16 @@ func HandleFileTransfer(conn net.Conn, recipientId, fileName string, fileSize in
 		}
 	}
 
-	fmt.Printf("%s File '%s' received successfully!\n", 
-	    utils.SuccessColor("✅"),
-	    utils.SuccessColor(fileName))
+	// Mark transfer as completed
+	UpdateTransferStatus(transferID, Completed)
+
+	fmt.Printf("%s File '%s' received successfully!\n",
+		utils.SuccessColor("✅"),
+		utils.SuccessColor(fileName))
 	fmt.Println(utils.InfoColor("📂 Saved to:"), utils.InfoColor(filePath))
+
+	// Clean up the transfer
+	RemoveTransfer(transferID)
 }
 
 func HandleDownloadRequest(conn net.Conn, recipientId, filePath string) {

--- a/client/internal/transfer.go
+++ b/client/internal/transfer.go
@@ -1,0 +1,48 @@
+package connection
+
+import (
+
+)
+
+type TransferType int
+
+const (
+	FileTransfer TransferType = iota
+	FolderTransfer
+)
+
+func (t TransferType) String() string {
+	switch t {
+	case FileTransfer:
+		return "File"
+	case FolderTransfer:
+		return "Folder"
+	default:
+		return "Unknown"
+	}
+}
+
+type TransferStatus int
+
+const (
+	Active TransferStatus = iota
+	Paused
+	Completed
+	Failed
+)
+
+func (s TransferStatus) String() string {
+	switch s {
+	case Active:
+		return "Active"
+	case Paused:
+		return "Paused"
+	case Completed:
+		return "Completed"
+	case Failed:
+		return "Failed"
+	default:
+		return "Unknown"
+	}
+}
+

--- a/client/internal/transfer.go
+++ b/client/internal/transfer.go
@@ -1,7 +1,12 @@
 package connection
 
 import (
-
+	"drizlink/utils"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"time"
 )
 
 type TransferType int
@@ -46,3 +51,90 @@ func (s TransferStatus) String() string {
 	}
 }
 
+type TransferReader interface {
+	Read(p []byte) (n int, err error)
+	GetBytesProcessed() int64
+}
+
+type TransferWriter interface {
+	Write(p []byte) (n int, err error)
+	GetBytesProcessed() int64
+}
+
+type Transfer struct {
+	ID            string
+	Type          TransferType
+	Name          string
+	Size          int64
+	BytesComplete int64
+	Status        TransferStatus
+	Direction     string 
+	Recipient     string
+	Path          string
+	Checksum      string
+	StartTime     time.Time
+	File          *os.File
+	Connection    net.Conn
+	ProgressBar   *utils.ProgressBar
+	pauseMutex    sync.Mutex
+	isPaused      bool
+}
+
+var (
+	ActiveTransfers   = make(map[string]*Transfer)
+	TransfersMutex    sync.RWMutex
+	transferIDCounter = 1
+	DefaultManager    *TransferManager
+)
+
+func init() {
+	DefaultManager = NewTransferManager()
+}
+
+type TransferManager struct {
+	transfers      map[string]*Transfer
+	mutex          sync.RWMutex
+	nextID         int
+}
+
+func NewTransferManager() *TransferManager {
+	return &TransferManager{
+		transfers: make(map[string]*Transfer),
+		nextID:    1,
+	}
+}
+
+func (tm *TransferManager) GenerateID() string {
+	tm.mutex.Lock()
+	defer tm.mutex.Unlock()
+	id := strconv.Itoa(tm.nextID)
+	tm.nextID++
+	return id
+}
+
+// GenerateTransferID creates a unique ID for a transfer (legacy function for compatibility)
+func GenerateTransferID() string {
+	return DefaultManager.GenerateID()
+}
+
+func (tm *TransferManager) Register(transfer *Transfer) {
+	tm.mutex.Lock()
+	defer tm.mutex.Unlock()
+	tm.transfers[transfer.ID] = transfer
+}
+
+// RegisterTransfer adds a new transfer to the tracking system (legacy function for compatibility)
+func RegisterTransfer(transfer *Transfer) {
+	DefaultManager.Register(transfer)
+	// Also maintain old behavior for backward compatibility
+	TransfersMutex.Lock()
+	defer TransfersMutex.Unlock()
+	ActiveTransfers[transfer.ID] = transfer
+}
+
+func (tm *TransferManager) Get(id string) (*Transfer, bool) {
+	tm.mutex.RLock()
+	defer tm.mutex.RUnlock()
+	transfer, exists := tm.transfers[id]
+	return transfer, exists
+}

--- a/utils/ui.go
+++ b/utils/ui.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/fatih/color"
@@ -18,31 +19,19 @@ var (
 	HeaderColor  = color.New(color.FgMagenta, color.Bold).SprintFunc()
 	CommandColor = color.New(color.FgBlue, color.Bold).SprintFunc()
 	UserColor    = color.New(color.FgGreen, color.Bold).SprintFunc()
+	PausedColor  = color.New(color.FgYellow, color.Bold).SprintFunc()
 )
 
-// PrintHelp displays all available commands
-func PrintHelp() {
-	fmt.Println(HeaderColor("\n📚 DrizLink Help - Available Commands 📚"))
-	fmt.Println(InfoColor("------------------------------------------------"))
-	
-	fmt.Println(HeaderColor("\n🌐 General Commands:"))
-	fmt.Printf("  %s - Show online users\n", CommandColor("/status"))
-	fmt.Printf("  %s - Show this help message\n", CommandColor("/help"))
-	fmt.Printf("  %s - Disconnect and exit\n", CommandColor("exit"))
-	
-	fmt.Println(HeaderColor("\n📁 File Operations:"))
-	fmt.Printf("  %s - Browse user's shared files\n", CommandColor("/lookup <userId>"))
-	fmt.Printf("  %s - Send a file to user\n", CommandColor("/sendfile <userId> <filePath>"))
-	fmt.Printf("  %s - Send a folder to user\n", CommandColor("/sendfolder <userId> <folderPath>"))
-	fmt.Printf("  %s - Download a file from user\n", CommandColor("/download <userId> <fileName>"))
-	
-	fmt.Println(InfoColor("------------------------------------------------"))
-	fmt.Println(InfoColor("Type a message and press Enter to send to everyone\n"))
+type ProgressBar struct {
+	Bar       *progressbar.ProgressBar
+	IsPaused  bool
+	Mutex     sync.Mutex
+	TransferId string
 }
 
-// CreateProgressBar creates and returns a progress bar for file transfers
-func CreateProgressBar(size int64, description string) *progressbar.ProgressBar {
-	return progressbar.NewOptions64(
+// CreateProgressBar creates and returns a custom progress bar for file transfers
+func CreateProgressBar(size int64, description string) *ProgressBar {
+	bar := progressbar.NewOptions64(
 		size,
 		progressbar.OptionSetDescription(description),
 		progressbar.OptionEnableColorCodes(true),
@@ -61,6 +50,69 @@ func CreateProgressBar(size int64, description string) *progressbar.ProgressBar 
 			fmt.Fprint(os.Stdout, "\n")
 		}),
 	)
+	
+	return &ProgressBar{
+		Bar:      bar,
+		IsPaused: false,
+	}
+}
+
+func (pb *ProgressBar) Write(p []byte) (n int, err error) {
+	pb.Mutex.Lock()
+	defer pb.Mutex.Unlock()
+	
+	if pb.IsPaused {
+		return len(p), nil
+	}
+	
+	return pb.Bar.Write(p)
+}
+
+func (pb *ProgressBar) SetPaused(paused bool) {
+	pb.Mutex.Lock()
+	defer pb.Mutex.Unlock()
+	
+	pb.IsPaused = paused
+	
+	description := pb.Bar.String()
+	if paused {
+		pb.Bar.Describe(fmt.Sprintf("%s %s", description, PausedColor("[PAUSED]")))
+	} else {
+		pb.Bar.Describe(description)
+	}
+}
+
+func (pb *ProgressBar) GetTransferId() string {
+	return pb.TransferId
+}
+
+func (pb *ProgressBar) SetTransferId(id string) {
+	pb.TransferId = id
+}
+
+// PrintHelp displays all available commands
+func PrintHelp() {
+	fmt.Println(HeaderColor("\n📚 DrizLink Help - Available Commands 📚"))
+	fmt.Println(InfoColor("------------------------------------------------"))
+	
+	fmt.Println(HeaderColor("\n🌐 General Commands:"))
+	fmt.Printf("  %s - Show online users\n", CommandColor("/status"))
+	fmt.Printf("  %s - Show this help message\n", CommandColor("/help"))
+	fmt.Printf("  %s - Disconnect and exit\n", CommandColor("exit"))
+	
+	fmt.Println(HeaderColor("\n📁 File Operations:"))
+	fmt.Printf("  %s - Browse user's shared files\n", CommandColor("/lookup <userId>"))
+	fmt.Printf("  %s - Send a file to user\n", CommandColor("/sendfile <userId> <filePath>"))
+	fmt.Printf("  %s - Send a folder to user\n", CommandColor("/sendfolder <userId> <folderPath>"))
+	fmt.Printf("  %s - Download a file from user\n", CommandColor("/download <userId> <fileName>"))
+	
+	fmt.Println(HeaderColor("\n📡 Transfer Controls:"))
+	fmt.Printf("  %s - Show all active transfers\n", CommandColor("/transfers"))
+	fmt.Printf("  %s - Pause an active transfer\n", CommandColor("/pause <transferId>"))
+	fmt.Printf("  %s - Resume a paused transfer\n", CommandColor("/resume <transferId>"))
+	
+	fmt.Println(InfoColor("------------------------------------------------"))
+	fmt.Println(InfoColor("Type a message and press Enter to send to everyone\n"))
 }
 
 // PrintBanner prints the application banner


### PR DESCRIPTION
# PR: Implement Pause/Resume Functionality for File Transfers

## Description
This PR introduces pause/resume functionality for file transfers in DrizLink, allowing users to have better control over their transfers and network resources.

## Changes

### Core Features
- Added pause/resume support for active file transfers
- Implemented checkpoint system to track transfer progress
- Added transfer status tracking and management
- Enhanced progress reporting with pause/resume states

### New Commands
- `/pause <transferId>` - Pause an active transfer
- `/resume <transferId>` - Resume a paused transfer
- `/transfers` - View all active and paused transfers

### UI/UX Improvements
- Added visual indicators for paused transfers
- Enhanced progress bar to show transfer status
- Color-coded transfer states in the UI
- Improved transfer status messages

### Technical Implementation
- Created `TransferManager` to handle transfer states
- Implemented `CheckpointedReader` and `CheckpointedWriter` for resumable I/O
- Added transfer status tracking with thread-safe operations
- Implemented proper error handling for paused transfers

## Related Issues
Closes #1 

## Notes
- Transfers paused for more than 24 hours will be automatically cancelled
- Progress is tracked at the chunk level for efficient resuming
- Transfer IDs can be found using the `/transfers` command